### PR TITLE
fix pass.setSize is not a function

### DIFF
--- a/build/threecap.js
+++ b/build/threecap.js
@@ -238,6 +238,8 @@ function THREEcapRenderPass(scriptbase) {
 	this.scene.add( this.quad );
 
 	this.threecap = new THREEcap({useWorker: true, quality: 'veryfast', fps: 30, scriptbase: scriptbase, renderpass: this});
+    
+    this.setSize = function() {}
 };
 
 THREEcapRenderPass.prototype = {


### PR DESCRIPTION
fix for issue #1, adding a dummy function `setSize = function() {} ` to `THREEcapRenderPass` seems to do the trick